### PR TITLE
Added the setTargetting for page targeting properties.

### DIFF
--- a/angular-dfp.js
+++ b/angular-dfp.js
@@ -33,6 +33,11 @@ angular.module('ngDfp', [])
     var enabled = true;
 
     /**
+     Defined Page targetting key->values
+    */
+    var pageTargeting = {};
+
+    /**
      This initializes the dfp script in the document. Loosely based on angular-re-captcha's
      method of loading the script with promises.
 
@@ -74,6 +79,13 @@ angular.module('ngDfp', [])
           if(sizeMapping[id]){
             definedSlots[id].defineSizeMapping(sizeMapping[id]);
           }
+        });
+
+	/**
+         Set the page targetting key->values
+        */
+        angular.forEach(pageTargeting, function (value, key) {
+          googletag.pubads().setTargeting(key,value);
         });
 
         googletag.pubads().enableSingleRequest();
@@ -154,6 +166,13 @@ angular.module('ngDfp', [])
      */
     this.setEnabled = function (setting) {
       enabled = setting;
+    };
+
+    /**
+     Stores page targetting key->values
+    */
+    this.setPageTargeting = function () {
+      pageTargeting[arguments[0]] = arguments[1];
     };
 
     // Public factory API.

--- a/angular-dfp.js
+++ b/angular-dfp.js
@@ -85,7 +85,7 @@ angular.module('ngDfp', [])
          Set the page targeting key->values
          */
         angular.forEach(pageTargeting, function (value, key) {
-          googletag.pubads().setTargeting(key,value);
+          googletag.pubads().setTargeting(key, value);
         });
 
         googletag.pubads().enableSingleRequest();

--- a/angular-dfp.js
+++ b/angular-dfp.js
@@ -171,8 +171,8 @@ angular.module('ngDfp', [])
     /**
      Stores page targeting key->values
      */
-    this.setPageTargeting = function () {
-      pageTargeting[arguments[0]] = arguments[1];
+    this.setPageTargeting = function (key, value) {
+      pageTargeting[key] = value;
     };
 
     // Public factory API.

--- a/angular-dfp.js
+++ b/angular-dfp.js
@@ -33,8 +33,8 @@ angular.module('ngDfp', [])
     var enabled = true;
 
     /**
-     Defined Page targetting key->values
-    */
+     Defined Page targeting key->values
+     */
     var pageTargeting = {};
 
     /**
@@ -82,8 +82,8 @@ angular.module('ngDfp', [])
         });
 
 	/**
-         Set the page targetting key->values
-        */
+         Set the page targeting key->values
+         */
         angular.forEach(pageTargeting, function (value, key) {
           googletag.pubads().setTargeting(key,value);
         });
@@ -169,8 +169,8 @@ angular.module('ngDfp', [])
     };
 
     /**
-     Stores page targetting key->values
-    */
+     Stores page targeting key->values
+     */
     this.setPageTargeting = function () {
       pageTargeting[arguments[0]] = arguments[1];
     };


### PR DESCRIPTION
Noticed that this module doesn't have the possibility of using the setTargeting functionality from DFP (check docs here: https://support.google.com/dfp_sb/answer/1698183) and because we need it I've added the Page-level customized targeting functionality to it.

Usage example:
```
DoubleClickProvider.setPageTargeting(propertyName,propertyValue);
```

Hope this helps others.